### PR TITLE
Enhanced delta_ranking method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # crypto-analysis
-Daily analysis of the top100 cryptos from coinmarketcap
+Tools for getting [CoinMarketCap](https://coinmarketcap.com/) top 100 cryptocurrencies by market capitalization and some insights about temporal evolution
+
+## Getting Started
+
+This package works with Python 3.6. To install it, follow this procedure:
+
+```
+git clone https://github.com/mauryaland/crypto-analysis.git
+cd crypto-analysis
+pip install .
+```
+## Examples
+
+To learn how to use this package, please take a look at this [notebook](https://github.com/mauryaland/crypto-analysis/blob/master/examples/cryptorocket_usage.ipynb) !
+
+## Next steps
+
+- Automatic scheduler to get data everyday
+- Consistent time series analysis using the implemented methods
+- Automatically (and luckily) find new cryptocurrency soaring to the moon
+
+## Acknowledgments
+
+Awesome [CoinMarketCap Public API](https://coinmarketcap.com/fr/api/) which will migrates to the [professional API](https://pro.coinmarketcap.com/) on December 4th, 2018.

--- a/cryptorocket/comparison.py
+++ b/cryptorocket/comparison.py
@@ -40,12 +40,14 @@ class CMComparison():
         # Compute the delta_rank dataframe
         index = []
         delta_rank = []
-        for i in self.df_old.index:
-            if i in self.df_fresh.index:
-                index.append(i)
-                delta_rank.append(round(self.df_old['rank'].loc[i] - self.df_fresh['rank'].loc[i]))
-        delta_df = pd.DataFrame(data={'delta_rank': delta_rank}, index=index, dtype=np.int64)
-        
+        for i in self.df_fresh.index:
+            index.append(i)
+            if i in self.df_old.index:
+                delta_rank.append(self.df_old['rank'].loc[i] - self.df_fresh['rank'].loc[i])
+            else:
+                delta_rank.append(101 - self.df_fresh['rank'].loc[i])
+            delta_df = pd.DataFrame(data={'delta_rank': delta_rank}, index=index, dtype=np.int64)
+            
         return delta_df
     
     def pct_change_market_cap(self):


### PR DESCRIPTION
If a cryptocurrency enters in the top100, the delta ranking is calculated in this way:
101 - current position
We use 101 because if a cryptocurrency enters at position 100, it will have a positive delta ranking while if this cryptocurrency stays at position 100 from one date to another, its delta ranking will be 0.